### PR TITLE
Fix extension stripping

### DIFF
--- a/patch.py
+++ b/patch.py
@@ -91,7 +91,7 @@ def main():
         )
         exit(1)
 
-    target_apk_unpacked = target_apk.rstrip(".apk")
+    target_apk_unpacked = os.path.splitext(target_apk)[0]
     target_apk_repacked = target_apk_unpacked + ".repack.apk"
 
     # Unpacking


### PR DESCRIPTION
The existing code:

```py
target_apk_unpacked = target_apk.rstrip(".apk")
```

will remove any of the characters in the set `.apk` from the right side of the string. For example, if `target_apk` is `my_app_apk.apk`, then `target_apk_unpacked` will end up as just `my_app_`. To remove _only_ the extension from the `target_apk` path, do this instead:

```py
target_apk_unpacked = os.path.splitext(target_apk)[0]
```